### PR TITLE
Support arbitrary rasterizer viewport size

### DIFF
--- a/src/render/batch_renderer.cpp
+++ b/src/render/batch_renderer.cpp
@@ -108,7 +108,8 @@ static HeapArray<LayeredTarget> makeLayeredTargets(uint32_t width,
             .lightingSet = {},
             .pixelWidth = image_width,
             .pixelHeight = image_height,
-            .viewDim = width,
+            .viewWidth = width,
+            .viewHeight = height,
         };
 
         VkImageViewCreateInfo view_info = {};
@@ -1144,19 +1145,19 @@ static void issueRasterization(vk::Device &dev,
 
         // Set viewport and scissor
         VkViewport viewport = {
-            .x = (float)(image_x * target.viewDim),
-            .y = (float)(image_y * target.viewDim),
-            .width = (float)target.viewDim,
-            .height = (float)target.viewDim,
+            .x = (float)(image_x * target.viewWidth),
+            .y = (float)(image_y * target.viewHeight),
+            .width = (float)target.viewWidth,
+            .height = (float)target.viewHeight,
             .minDepth = 0.f,
             .maxDepth = 1.f
         };
 
         VkRect2D rect = {
-            .offset = { (int32_t)(image_x * target.viewDim),
-                        (int32_t)(image_y * target.viewDim) },
-            .extent = { (uint32_t)target.viewDim,
-                        (uint32_t)target.viewDim }
+            .offset = { (int32_t)(image_x * target.viewWidth),
+                        (int32_t)(image_y * target.viewHeight) },
+            .extent = { (uint32_t)target.viewWidth,
+                        (uint32_t)target.viewHeight }
         };
 
         dev.dt.cmdSetViewport(draw_cmd, 0, 1, &viewport);
@@ -1194,15 +1195,16 @@ static void issueDeferred(vk::Device &dev,
                           VkDescriptorSet asset_mat_tex_set,
                           VkDescriptorSet index_buffer_set,
                           VkDescriptorSet pbr_set,
-                          uint32_t view_dim) 
+                          uint32_t view_width,
+                          uint32_t view_height) 
 {
     (void)asset_set;
     (void)asset_mat_tex_set;
 
-    uint32_t max_image_dim = consts::maxNumImagesX * view_dim;
+    uint32_t max_image_dim = consts::maxNumImagesX * view_width;
 
-    uint32_t max_images_x = max_image_dim / view_dim;
-    uint32_t max_images_y = max_image_dim / view_dim;
+    uint32_t max_images_x = max_image_dim / view_width;
+    uint32_t max_images_y = max_image_dim / view_height;
 
     // The output buffer has been transitioned to general at the start of the frame.
     // The viz buffers have been transitioned to general before this happens.
@@ -1211,7 +1213,8 @@ static void issueDeferred(vk::Device &dev,
     shader::DeferredLightingPushConstBR push_const = {
         .maxImagesXPerTarget = max_images_x,
         .maxImagesYPerTarget = max_images_y,
-        .viewDim = view_dim
+        .viewWidth = view_width,
+        .viewHeight = view_height
     };
 
     dev.dt.cmdPushConstants(draw_cmd, pipeline.layout,
@@ -1595,10 +1598,6 @@ static void computeLights(EngineInterop *interop, uint32_t num_worlds, uint32_t 
     LightDesc *lightDescs = (LightDesc *)interop->bridge.lights;
     printf(">>>>>>>>>num_worlds: %d, num_lightsPerWorld: %d\n", num_worlds, num_lightsPerWorld);
     for (uint32_t i = 0; i < num_worlds * num_lightsPerWorld; ++i) {
-        printf(">>>>>>>>>lightDescs[%d]: %d\n", i, lightDescs[i].type);
-        printf(">>>>>>>>>lightDescs[%d]: %f\n", i, lightDescs[i].intensity);
-        printf(">>>>>>>>>lightDescs[%d]: %f, %f, %f\n", i, lightDescs[i].direction.x, lightDescs[i].direction.y, lightDescs[i].direction.z);
-        printf(">>>>>>>>>lightDescs[%d]: %f, %f, %f\n", i, lightDescs[i].position.x, lightDescs[i].position.y, lightDescs[i].position.z);
         if(lightDescs[i].type == LightDesc::Type::Directional) {
             lights[i] = {
                 .lightDir = math::Vector4::fromVec3W(lightDescs[i].direction, 0.0f),
@@ -2101,7 +2100,8 @@ void BatchRenderer::renderViews(BatchRenderInfo info,
         impl->assetSetTextureMat,
         loaded_assets[0].indexBufferSet,
         frame_data.pbrSet,
-        frame_data.targets[0].viewDim);
+        frame_data.targets[0].viewWidth,
+        frame_data.targets[0].viewHeight);
 
     impl->dev.dt.cmdWriteTimestamp(draw_cmd, 
                 VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, impl->timeQueryPool, 1);

--- a/src/render/batch_renderer.hpp
+++ b/src/render/batch_renderer.hpp
@@ -35,7 +35,8 @@ struct LayeredTarget {
     uint32_t pixelWidth;
     uint32_t pixelHeight;
 
-    uint32_t viewDim;
+    uint32_t viewWidth;
+    uint32_t viewHeight;
 };
 
 struct BatchRenderInfo {

--- a/src/render/shaders/draw_deferred_depth.hlsl
+++ b/src/render/shaders/draw_deferred_depth.hlsl
@@ -563,10 +563,10 @@ void lighting(uint3 idx : SV_DispatchThreadID)
     uint target_view_idx_y = target_view_idx /
                              pushConst.maxImagesXPerTarget;
 
-    float x_pixel_offset = target_view_idx_x * pushConst.viewDim;
-    float y_pixel_offset = target_view_idx_y * pushConst.viewDim;
+    float x_pixel_offset = target_view_idx_x * pushConst.viewWidth;
+    float y_pixel_offset = target_view_idx_y * pushConst.viewHeight;
 
-    if (idx.x >= pushConst.viewDim || idx.y >= pushConst.viewDim) {
+    if (idx.x >= pushConst.viewWidth || idx.y >= pushConst.viewHeight) {
         return;
     }
 
@@ -574,17 +574,16 @@ void lighting(uint3 idx : SV_DispatchThreadID)
 
     float2 vbuffer_pixel_clip =
         float2(float(vbuffer_pixel.x) + 0.5f, float(vbuffer_pixel.y) + 0.5f) /
-        float2(pushConst.viewDim, pushConst.viewDim);
+        float2(pushConst.viewWidth, pushConst.viewHeight);
 
     vbuffer_pixel_clip = vbuffer_pixel_clip * 2.0f - float2(1.0f, 1.0f);
     vbuffer_pixel_clip.y *= -1.0;
 
     uint2 sample_uv_u32 = vbuffer_pixel.xy + uint2(x_pixel_offset, y_pixel_offset);
 
-    uint total_res = pushConst.viewDim * pushConst.maxImagesXPerTarget;
+    float2 total_res = float2(pushConst.viewWidth * pushConst.maxImagesXPerTarget, pushConst.viewHeight * pushConst.maxImagesYPerTarget);
 
-    float2 sample_uv = float2(sample_uv_u32) / 
-                       float2(total_res, total_res);
+    float2 sample_uv = float2(sample_uv_u32) / total_res;
     sample_uv.y = 1.0 - sample_uv.y;
 
     // Apply the offset when reading the pixel value from the image
@@ -675,7 +674,7 @@ void lighting(uint3 idx : SV_DispatchThreadID)
                 vertices[1].postMvp,
                 vertices[2].postMvp,
                 vbuffer_pixel_clip,
-                float2(pushConst.viewDim, pushConst.viewDim));
+                float2(pushConst.viewWidth, pushConst.viewHeight));
 
         float interpolated_w = 1.0f / dot(w_inv, bc.m_lambda);
 
@@ -708,7 +707,7 @@ void lighting(uint3 idx : SV_DispatchThreadID)
     // Lighting calculations
     float3 outgoing_ray = getOutgoingRay(
         float2(vbuffer_pixel.xy),
-        float2(pushConst.viewDim, pushConst.viewDim),
+        float2(pushConst.viewWidth, pushConst.viewHeight),
         view_data);
     float4 point_radiance = getPointRadianceBRDF(roughness, metalness, gbuffer_data, view_data, vbuffer_pixel.xy);
 
@@ -748,8 +747,8 @@ void lighting(uint3 idx : SV_DispatchThreadID)
     out_color.x += zeroDummy();
 
     uint32_t out_pixel_idx =
-        view_idx * pushConst.viewDim * pushConst.viewDim +
-        idx.y * pushConst.viewDim + idx.x;
+        view_idx * pushConst.viewWidth * pushConst.viewHeight +
+        idx.y * pushConst.viewWidth + idx.x;
 
     rgbOutputBuffer[out_pixel_idx] = linearToSRGB8(float3(0 + zeroDummy(), 0, 0)); 
     depthOutputBuffer[out_pixel_idx] = depth;

--- a/src/render/shaders/draw_deferred_rgb.hlsl
+++ b/src/render/shaders/draw_deferred_rgb.hlsl
@@ -563,10 +563,10 @@ void lighting(uint3 idx : SV_DispatchThreadID)
     uint target_view_idx_y = target_view_idx /
                              pushConst.maxImagesXPerTarget;
 
-    float x_pixel_offset = target_view_idx_x * pushConst.viewDim;
-    float y_pixel_offset = target_view_idx_y * pushConst.viewDim;
+    float x_pixel_offset = target_view_idx_x * pushConst.viewWidth;
+    float y_pixel_offset = target_view_idx_y * pushConst.viewHeight;
 
-    if (idx.x >= pushConst.viewDim || idx.y >= pushConst.viewDim) {
+    if (idx.x >= pushConst.viewWidth || idx.y >= pushConst.viewHeight) {
         return;
     }
 
@@ -574,17 +574,16 @@ void lighting(uint3 idx : SV_DispatchThreadID)
 
     float2 vbuffer_pixel_clip =
         float2(float(vbuffer_pixel.x) + 0.5f, float(vbuffer_pixel.y) + 0.5f) /
-        float2(pushConst.viewDim, pushConst.viewDim);
+        float2(pushConst.viewWidth, pushConst.viewHeight);
 
     vbuffer_pixel_clip = vbuffer_pixel_clip * 2.0f - float2(1.0f, 1.0f);
     vbuffer_pixel_clip.y *= -1.0;
 
     uint2 sample_uv_u32 = vbuffer_pixel.xy + uint2(x_pixel_offset, y_pixel_offset);
 
-    uint total_res = pushConst.viewDim * pushConst.maxImagesXPerTarget;
+    float2 total_res = float2(pushConst.viewWidth * pushConst.maxImagesXPerTarget, pushConst.viewHeight * pushConst.maxImagesYPerTarget);
 
-    float2 sample_uv = float2(sample_uv_u32) / 
-                       float2(total_res, total_res);
+    float2 sample_uv = float2(sample_uv_u32) / total_res;
     sample_uv.y = 1.0 - sample_uv.y;
 
     // Apply the offset when reading the pixel value from the image
@@ -620,8 +619,8 @@ void lighting(uint3 idx : SV_DispatchThreadID)
     out_color.x += zeroDummy();
 
     uint32_t out_pixel_idx =
-        view_idx * pushConst.viewDim * pushConst.viewDim +
-        idx.y * pushConst.viewDim + idx.x;
+        view_idx * pushConst.viewWidth * pushConst.viewHeight +
+        idx.y * pushConst.viewWidth + idx.x;
 
     rgbOutputBuffer[out_pixel_idx] = linearToSRGB8(out_color); 
     depthOutputBuffer[out_pixel_idx] = depth;

--- a/src/render/shaders/shader_common.h
+++ b/src/render/shaders/shader_common.h
@@ -36,7 +36,8 @@ struct PrepareViewPushConstant {
 struct DeferredLightingPushConstBR {
     uint32_t maxImagesXPerTarget;
     uint32_t maxImagesYPerTarget;
-    uint32_t viewDim;
+    uint32_t viewWidth;
+    uint32_t viewHeight;
 };
 
 struct BlurPushConst {


### PR DESCRIPTION
The math to calculate number of views per target is wrong, since it doesn't take hardware limitation of texture size into consideration.


E.g., when rendering with output size (2048 * 512) with more than 256 batches.  Output from views >=256 will have empty data.