### PR TITLE
Fix the memory alignment issue with LightDesc

### DIFF
--- a/include/madrona/render/ecs.hpp
+++ b/include/madrona/render/ecs.hpp
@@ -39,7 +39,7 @@ struct alignas(16) PerspectiveCameraData {
     float yScale;
     float zNear;
     int32_t worldIDX;
-    uint32_t pad;
+    uint32_t padding;
 };
 
 // For private usage - not to be used by user.
@@ -75,19 +75,22 @@ struct alignas(16) LightDesc {
     // Intensity of the light. (1.f is default)
     float intensity;
 
-    enum Type : uint32_t {
-        Directional = 1,
-        Spotlight = 0
+    enum Type : bool {
+        Spotlight = 0,
+        Directional = 1
     };
 
     // Type of the light.
     Type type;
 
     // Whether the light casts a shadow.
-    uint32_t castShadow;
+    bool castShadow;
 
     // Gives ability to turn light on or off.
-    uint32_t active;
+    bool active;
+
+    bool padding1 = false;
+    float padding2[3] = {0, 0, 0};
 };
 
 struct LightDescDirection : math::Vector3 {

--- a/src/render/shaders/batch_draw_rgb.hlsl
+++ b/src/render/shaders/batch_draw_rgb.hlsl
@@ -152,7 +152,7 @@ PixelOutput frag(in V2F v2f,
 
         [unroll(1)]
         for (uint i = 0; i < numLights; i++) {
-            LightDesc light = unpackLightData(lightDataBuffer[v2f.worldIdx * numLights + i]);
+            ShaderLightData light = unpackLightData(lightDataBuffer[v2f.worldIdx * numLights + i]);
             if(!light.active) {
                 continue;
             }

--- a/src/render/shaders/draw_deferred_rgb.hlsl
+++ b/src/render/shaders/draw_deferred_rgb.hlsl
@@ -37,7 +37,7 @@ StructuredBuffer<uint32_t> instanceOffsets;
 
 // Lighting
 [[vk::binding(0, 3)]]
-StructuredBuffer<LightDesc> lights;
+StructuredBuffer<PackedLightData> lights;
 
 [[vk::binding(1, 3)]]
 Texture2D<float4> transmittanceLUT;
@@ -313,13 +313,14 @@ float3 accumulateSunRadianceBRDF(in GBufferData gbuffer,
     float3 radiance_from_sun = skyBuffer[0].solarIrradiance.xyz * 
                                getTransmittanceToSun(skyBuffer[0], transmittanceLUT, r, mu_sun);
 
+    ShaderLightData light = unpackLightData(lights[0]);
     ret += directionalRadianceBRDF(gbuffer,
                                    lerp(float3(0.04, 0.04, 0.04), gbuffer.albedo.rgb, metal),
                                    roughness,
                                    metal,
                                    normalize(gbuffer.wPosition.xyz - camera_data.pos.xyz),
                                    radiance_from_sun,
-                                   normalize(-lights[0].direction.xyz));
+                                   normalize(-light.direction.xyz));
 
     return ret * 1.0;
 }
@@ -338,7 +339,8 @@ float4 getPointRadianceBRDF(float roughness, float metal,
         float3 p = gbuffer.wPosition / 1000.0 - skyBuffer[0].wPlanetCenter.xyz;
         float3 normal = gbuffer.wNormal;
 
-        float3 sun_direction = -normalize(lights[0].direction.xyz);
+        ShaderLightData light = unpackLightData(lights[0]);
+        float3 sun_direction = -normalize(light.direction.xyz);
 
         float3 view_direction = normalize(gbuffer.wPosition - camera_data.pos.xyz);
 
@@ -356,11 +358,12 @@ float4 getPointRadianceBRDF(float roughness, float metal,
 
     /* How much is scattered towards us. */
     float3 transmittance;
+    ShaderLightData light = unpackLightData(lights[0]);
     float3 in_scatter = getSkyRadianceToPoint(skyBuffer[0], transmittanceLUT,
                                               scatteringLUT, scatteringLUT,
                                               camera_data.pos.xyz / 1000.0 - skyBuffer[0].wPlanetCenter.xyz,
                                               gbuffer.wPosition / 1000.0 - skyBuffer[0].wPlanetCenter.xyz, 0.0,
-                                              -normalize(lights[0].direction.xyz),
+                                              -normalize(light.direction.xyz),
                                               transmittance);
 
     point_radiance = point_radiance * transmittance + in_scatter;

--- a/src/render/shaders/shader_common.h
+++ b/src/render/shaders/shader_common.h
@@ -205,7 +205,7 @@ struct DirectionalLight {
 */
 
 // Only used in shaders
-struct LightDesc {
+struct ShaderLightData {
     float3 position;
     float3 direction;
     float cutoffAngle;

--- a/src/render/shaders/shader_utils.hlsl
+++ b/src/render/shaders/shader_utils.hlsl
@@ -78,20 +78,21 @@ EngineInstanceData unpackEngineInstanceData(PackedInstanceData packed)
     return o;
 }
 
-LightDesc unpackLightData(PackedLightData packed)
+ShaderLightData unpackLightData(PackedLightData packed)
 {
     const float4 d0 = packed.data[0];
     const float4 d1 = packed.data[1];
     const float4 d2 = packed.data[2];
 
-    LightDesc o;
+    ShaderLightData o;
     o.position = d0.xyz;
     o.direction = float3(d0.w, d1.xy);
     o.cutoffAngle = d1.z;
     o.intensity = d1.w;
-    o.isDirectional = asuint(d2.x);
-    o.castShadow = asuint(d2.y);
-    o.active = asuint(d2.z);
+    const uint32_t rest = asuint(d2.x);
+    o.isDirectional = (rest & 0xFF) != 0;
+    o.castShadow = (rest & 0xFF00) != 0;
+    o.active = (rest & 0xFF0000) != 0;
 
     return o;
 }

--- a/src/render/shaders/shadow_gen.hlsl
+++ b/src/render/shaders/shadow_gen.hlsl
@@ -10,7 +10,7 @@ RWStructuredBuffer<ShadowViewData> shadowViewDataBuffer;
 StructuredBuffer<PackedViewData> flycamBuffer;
 
 [[vk::binding(2, 0)]]
-StructuredBuffer<LightDesc> lights;
+StructuredBuffer<PackedLightData> lights;
 
 [[vk::binding(3, 0)]]
 StructuredBuffer<PackedViewData> viewDataBuffer;
@@ -51,7 +51,8 @@ void shadowGen(uint3 idx : SV_DispatchThreadID)
     float3 cam_right = rotateVec(cam_rot, float3(1.0f, 0.0f, 0.0f));
 
     // Construct orthonormal basis
-    float3 light_fwd = normalize(lights[0].direction.xyz);
+    ShaderLightData light = unpackLightData(lights[0]);
+    float3 light_fwd = normalize(light.direction.xyz);
     float3 light_up = (light_fwd.x < 0.9999f) ?
         normalize(cross(float3(1.f, 0.f, 0.f), light_fwd)) :
         float3(0.f, 0.f, 1.f);

--- a/src/render/shaders/viewer_deferred_lighting.hlsl
+++ b/src/render/shaders/viewer_deferred_lighting.hlsl
@@ -16,7 +16,7 @@ RWTexture2D<float4> gbufferPosition;
 
 // Assume stuff is Y-UP from here
 [[vk::binding(3, 0)]]
-StructuredBuffer<LightDesc> lights;
+StructuredBuffer<PackedLightData> lights;
 
 // Atmosphere
 [[vk::binding(4, 0)]]
@@ -188,13 +188,14 @@ float3 accumulateSunRadianceBRDF(in GBufferData gbuffer,
     float3 radiance_from_sun = skyBuffer[0].solarIrradiance.xyz * 
                                getTransmittanceToSun(skyBuffer[0], transmittanceLUT, r, mu_sun);
 
+    ShaderLightData light = unpackLightData(lights[0]);
     ret += directionalRadianceBRDF(gbuffer,
                                    lerp(float3(0.04, 0.04, 0.04), gbuffer.albedo.rgb, metal),
                                    roughness,
                                    metal,
                                    normalize(gbuffer.wPosition.xyz - pushConst.viewPos.xyz),
                                    radiance_from_sun,
-                                   normalize(-lights[0].direction.xyz));
+                                   normalize(-light.direction.xyz));
 
     float shadow_factor = shadowFactorVSM(gbuffer.wPosition, target_pixel);
 
@@ -208,12 +209,13 @@ float3 accumulateSunRadianceBRDF(in GBufferData gbuffer,
 float4 getPointRadianceBRDF(float roughness, float metal, in GBufferData gbuffer, uint2 target_pixel) 
 {
     float3 sky_irradiance, sun_irradiance, point_radiance;
+    ShaderLightData light = unpackLightData(lights[0]);
 
     { /* Calculate sun and sky irradiance which will contribute to the final BRDF. */
         float3 p = gbuffer.wPosition / 1000.0 - skyBuffer[0].wPlanetCenter.xyz;
         float3 normal = gbuffer.wNormal;
 
-        float3 sun_direction = -normalize(lights[0].direction.xyz);
+        float3 sun_direction = -normalize(light.direction.xyz);
 
         float3 view_direction = normalize(gbuffer.wPosition - pushConst.viewPos.xyz);
 
@@ -235,7 +237,7 @@ float4 getPointRadianceBRDF(float roughness, float metal, in GBufferData gbuffer
                                               scatteringLUT, scatteringLUT,
                                               pushConst.viewPos.xyz / 1000.0 - skyBuffer[0].wPlanetCenter.xyz,
                                               gbuffer.wPosition / 1000.0 - skyBuffer[0].wPlanetCenter.xyz, 0.0,
-                                              -normalize(lights[0].direction.xyz),
+                                              -normalize(light.direction.xyz),
                                               transmittance);
 
     point_radiance = point_radiance * transmittance + in_scatter;
@@ -299,7 +301,8 @@ void lighting(uint3 idx : SV_DispatchThreadID)
         float4 point_radiance = getPointRadianceBRDF(roughness, metalness, 
                                                      gbuffer_data, target_pixel);
 
-        float3 sun_direction = normalize(-lights[0].direction.xyz);
+        ShaderLightData light = unpackLightData(lights[0]);
+        float3 sun_direction = normalize(-light.direction.xyz);
 
         /* Incoming radiance from the sky: */
         float3 transmittance;


### PR DESCRIPTION
The memory layout of LightDesc needs to be the same as the data passed from Genesis.
The generate output between rasterizer and raytracer with single bounce is now exactly the same.

ShadowGen, lighting pass only uses the first light and assume the first light is the directional light and cast shadows.  Need a more generic lighting model to address this properly.
Also not sure whether the light data passed to shadowgen and deferred lighting is correct or not.  The might be still using fake lights.