### PR TITLE
Fix crashes where there is 0 lights

### DIFF
--- a/src/render/batch_renderer.cpp
+++ b/src/render/batch_renderer.cpp
@@ -670,10 +670,13 @@ static void makeBatchFrame(vk::Device& dev,
     VkDeviceSize instance_offset_size = (cfg.numWorlds) * sizeof(uint32_t);
     vk::LocalBuffer instance_offsets = alloc.makeLocalBuffer(instance_offset_size).value();
 
+    // In case number of lights is 0, allocate a dummy buffer to avoid errors
     VkDeviceSize lights_size = cfg.numWorlds * cfg.maxLightsPerWorld * sizeof(LightDesc);
+    lights_size = std::max(lights_size, (VkDeviceSize)1024);
     vk::LocalBuffer lights = alloc.makeLocalBuffer(lights_size).value();
 
     VkDeviceSize light_offsets_size = cfg.numWorlds * sizeof(uint32_t);
+    light_offsets_size = std::max(light_offsets_size, (VkDeviceSize)1024);
     vk::LocalBuffer light_offsets = alloc.makeLocalBuffer(light_offsets_size).value();
 
     VkCommandPool prepare_cmdpool = vk::makeCmdPool(dev, dev.gfxQF);

--- a/src/render/render_ctx.cpp
+++ b/src/render/render_ctx.cpp
@@ -683,6 +683,8 @@ static EngineInterop setupEngineInterop(Device &dev,
     { // Create the lights buffer
         uint64_t num_lights_bytes = num_worlds * max_lights_per_world *
             (int64_t)sizeof(render::shader::PackedLightData);
+        // In case number of lights is 0, allocate a dummy buffer to avoid errors
+        num_lights_bytes = std::max(num_lights_bytes, (uint64_t)1024);
         if (!gpu_input) {
             lights_cpu = alloc.makeStagingBuffer(num_lights_bytes);
             lights_hdl = lights_cpu->buffer;


### PR DESCRIPTION
Allocate a dummy buffer with size=1024 for lights when there is no light