### PR TITLE
Enable CUDA kernel cache, and hardcode cache path in MWCudaExecutor ctor

### DIFF
--- a/src/mw/cuda_exec.cpp
+++ b/src/mw/cuda_exec.cpp
@@ -656,6 +656,7 @@ static GPUCompileResults compileCode(
     checkAndLoadMegakernelCache(kernel_cache, cache_write_path);
 
     if (kernel_cache.has_value()) {
+        printf("Loading kernel cache from cache\n");
         CUmodule mod;
         REQ_CU(cuModuleLoadData(&mod, kernel_cache->cubinStart));
 
@@ -2342,6 +2343,17 @@ MWCudaExecutor::MWCudaExecutor(
         const Optional<CudaBatchRenderConfig> &render_cfg)
     : impl_(nullptr)
 {
+    // Setup CUDA cache directory
+    if(!std::filesystem::exists("build")) {
+        std::filesystem::create_directories("build");
+    }
+    std::string kernel_cache_path = "build/kernel_cache";
+    std::string bvh_cache_path = "build/bvh_cache";
+    setenv("MADRONA_MWGPU_KERNEL_CACHE", kernel_cache_path.c_str(), 1);
+    setenv("MADRONA_BVH_KERNEL_CACHE", bvh_cache_path.c_str(), 1);
+    printf("Kernel cache directory set to: %s\n", kernel_cache_path.c_str());
+    printf("BVH cache directory set to: %s\n", bvh_cache_path.c_str());
+
     const ExecutorMode exec_mode = ExecutorMode::TaskGraph;
 
     auto strm = cu::makeStream();


### PR DESCRIPTION
Enable CUDA cache to speed up initialization