### PR TITLE
Fix rt lighting

### DIFF
--- a/include/madrona/render/ecs.hpp
+++ b/include/madrona/render/ecs.hpp
@@ -41,7 +41,6 @@ struct alignas(16) PerspectiveCameraData {
     float zNear;
     float zFar;
     int32_t worldIDX;
-    uint32_t padding;
 };
 
 // For private usage - not to be used by user.

--- a/include/madrona/render/ecs.hpp
+++ b/include/madrona/render/ecs.hpp
@@ -12,6 +12,7 @@ struct RenderCamera {
     // 1.0 / tanf(fovy * 0.5)
     float fovScale;
     float zNear;
+    float zFar;
 
     math::Vector3 cameraOffset;
 };
@@ -38,6 +39,7 @@ struct alignas(16) PerspectiveCameraData {
     float xScale;
     float yScale;
     float zNear;
+    float zFar;
     int32_t worldIDX;
     uint32_t padding;
 };
@@ -209,6 +211,7 @@ namespace RenderingSystem {
                             Entity e,
                             float vfov_degrees,
                             float z_near,
+                            float z_far,
                             const math::Vector3 &camera_offset);
 
     // Need to call these before destroying entities

--- a/src/bridge/madrona_gs/demo.py
+++ b/src/bridge/madrona_gs/demo.py
@@ -180,13 +180,12 @@ def output_depth(output_dir, depth, i_env, i_cam, i_step):
     cv2.imwrite(f'{output_dir}/depth_env{i_env}_cam{i_cam}_{i_step:03d}.png', depth_uint8)
 
 def output_rgb_and_depth(output_dir, rgb, depth, i_step):
-    bgr = rgb[..., [2, 1, 0]]
     # loop over the first and second dimension of rgb and depth
-    for i_env in range(bgr.shape[0]):
-        for i_cam in range(bgr.shape[1]):
+    for i_env in range(rgb.shape[0]):
+        for i_cam in range(rgb.shape[1]):
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
-            output_rgb(output_dir, bgr, i_env, i_cam, i_step)
+            output_rgb(output_dir, rgb, i_env, i_cam, i_step)
             output_depth(output_dir, depth, i_env, i_cam, i_step)
 
 def output_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx):
@@ -202,12 +201,11 @@ def output_depth_single_cam(output_dir, depth, i_env, i_step, cam_idx):
     cv2.imwrite(f'{output_dir}/depth_env{i_env}_cam{cam_idx}_{i_step:03d}.png', depth_uint8)
 
 def output_rgb_and_depth_single_cam(output_dir, rgb, depth, i_step, cam_idx):
-    bgr = rgb[..., [2, 1, 0]]
     # loop over the first and second dimension of rgb and depth
-    for i_env in range(bgr.shape[0]):
+    for i_env in range(rgb.shape[0]):
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
-        output_rgb_single_cam(output_dir, bgr, i_env, i_step, cam_idx)
+        output_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx)
         output_depth_single_cam(output_dir, depth, i_env, i_step, cam_idx)
 
 

--- a/src/bridge/madrona_gs/renderer_gs.py
+++ b/src/bridge/madrona_gs/renderer_gs.py
@@ -146,8 +146,9 @@ class MadronaBatchRendererAdapter:
         cam_pos,
         cam_rot,
     )
-    rgb_torch = self.madrona.rgb_tensor().to_torch()
-    depth_torch = self.madrona.depth_tensor().to_torch()    
+    # BGR to RGB
+    rgb_torch = self.madrona.rgb_tensor().to_torch()[..., [2, 1, 0]]
+    depth_torch = self.madrona.depth_tensor().to_torch()
     return rgb_torch, depth_torch
 
   def get_texture_data(self, rigid):

--- a/src/bridge/madrona_gs/simple_demo.py
+++ b/src/bridge/madrona_gs/simple_demo.py
@@ -29,7 +29,7 @@ def main():
             # constraint_solver=gs.constraint_solver.Newton,
         ),
         renderer = gs.options.renderers.BatchRenderer(
-            use_rasterizer=True,
+            use_rasterizer=False,
             batch_render_res=(512, 512),
         )
     )
@@ -118,13 +118,12 @@ def output_depth(output_dir, depth, i_env, i_cam, i_step):
     cv2.imwrite(f'{output_dir}/depth_env{i_env}_cam{i_cam}_{i_step:03d}.png', depth_uint8)
 
 def output_rgb_and_depth(output_dir, rgb, depth, i_step):
-    bgr = rgb[..., [2, 1, 0]]
     # loop over the first and second dimension of rgb and depth
-    for i_env in range(bgr.shape[0]):
-        for i_cam in range(bgr.shape[1]):
+    for i_env in range(rgb.shape[0]):
+        for i_cam in range(rgb.shape[1]):
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
-            output_rgb(output_dir, bgr, i_env, i_cam, i_step)
+            output_rgb(output_dir, rgb, i_env, i_cam, i_step)
             output_depth(output_dir, depth, i_env, i_cam, i_step)
 
 def output_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx):
@@ -140,12 +139,11 @@ def output_depth_single_cam(output_dir, depth, i_env, i_step, cam_idx):
     cv2.imwrite(f'{output_dir}/depth_env{i_env}_cam{cam_idx}_{i_step:03d}.png', depth_uint8)
 
 def output_rgb_and_depth_single_cam(output_dir, rgb, depth, i_step, cam_idx):
-    bgr = rgb[..., [2, 1, 0]]
     # loop over the first and second dimension of rgb and depth
-    for i_env in range(bgr.shape[0]):
+    for i_env in range(rgb.shape[0]):
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
-        output_rgb_single_cam(output_dir, bgr, i_env, i_step, cam_idx)
+        output_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx)
         output_depth_single_cam(output_dir, depth, i_env, i_step, cam_idx)
 
 

--- a/src/bridge/madrona_gs/simple_demo.py
+++ b/src/bridge/madrona_gs/simple_demo.py
@@ -29,7 +29,7 @@ def main():
             # constraint_solver=gs.constraint_solver.Newton,
         ),
         renderer = gs.options.renderers.BatchRenderer(
-            use_rasterizer=False,
+            use_rasterizer=True,
             batch_render_res=(512, 512),
         )
     )
@@ -111,7 +111,6 @@ def output_rgb(output_dir, rgb, i_env, i_cam, i_step):
 
 def output_depth(output_dir, depth, i_env, i_cam, i_step):
     depth = depth.cpu().numpy()[i_env, i_cam]
-    depth = np.asarray(depth)
     depth = np.clip(depth, 0, 100)
     depth_normalized = cv2.normalize(depth, None, 0, 255, cv2.NORM_MINMAX)
     depth_uint8 = depth_normalized.astype(np.uint8)
@@ -132,7 +131,6 @@ def output_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx):
 
 def output_depth_single_cam(output_dir, depth, i_env, i_step, cam_idx):
     depth = depth.cpu().numpy()[i_env]
-    depth = np.asarray(depth)
     depth = np.clip(depth, 0, 100)
     depth_normalized = cv2.normalize(depth, None, 0, 255, cv2.NORM_MINMAX)
     depth_uint8 = depth_normalized.astype(np.uint8)

--- a/src/bridge/madrona_gs/simple_demo.py
+++ b/src/bridge/madrona_gs/simple_demo.py
@@ -91,10 +91,10 @@ def main():
         scene.step()
         if do_batch_dump:
             rgb, depth, _, _ = scene.batch_render()
-            output_rgb_and_depth('img_output/test', rgb, depth, i)
+            export_rgb_and_depth('img_output/test', 10, rgb, depth, i, depth_scale='log')
         else:
             rgb, depth, _, _ = cam_0.render()
-            output_rgb_and_depth_single_cam('img_output/test', rgb, depth, i, cam_0.idx)
+            export_rgb_and_depth_single_cam('img_output/test', 10, rgb, depth, i, cam_0.idx, depth_scale='log')
     
     end_time = time()
     print(f'n_envs: {n_envs}')
@@ -103,47 +103,49 @@ def main():
     print(f'FPS: {n_envs * n_steps / (end_time - start_time)}')
     print(f'FPS per env: {n_steps / (end_time - start_time)}')
 
-
-# TODO: Dump image faster, e.g., asynchronously or generate a video instead of saving images.
-def output_rgb(output_dir, rgb, i_env, i_cam, i_step):
+# TODO: Export image faster, e.g., asynchronously or generate a video instead of saving images.
+def export_rgb(output_dir, rgb, i_env, i_cam, i_step):
     rgb = rgb.cpu().numpy()[i_env, i_cam]
     cv2.imwrite(f'{output_dir}/rgb_env{i_env}_cam{i_cam}_{i_step:03d}.png', rgb)
 
-def output_depth(output_dir, depth, i_env, i_cam, i_step):
+def export_depth(output_dir, depth_cutoff_dist, depth, i_env, i_cam, i_step, depth_scale='linear'):
     depth = depth.cpu().numpy()[i_env, i_cam]
-    depth = np.clip(depth, 0, 100)
+    depth = np.clip(depth, 0, depth_cutoff_dist)
+    if depth_scale == 'log':
+        depth = np.log1p(depth)  # log1p is log(1+x) which handles 0 values safely
     depth_normalized = cv2.normalize(depth, None, 0, 255, cv2.NORM_MINMAX)
     depth_uint8 = depth_normalized.astype(np.uint8)
     cv2.imwrite(f'{output_dir}/depth_env{i_env}_cam{i_cam}_{i_step:03d}.png', depth_uint8)
 
-def output_rgb_and_depth(output_dir, rgb, depth, i_step):
+def export_rgb_and_depth(output_dir, depth_cutoff_dist, rgb, depth, i_step, depth_scale='linear'):
     # loop over the first and second dimension of rgb and depth
     for i_env in range(rgb.shape[0]):
         for i_cam in range(rgb.shape[1]):
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
-            output_rgb(output_dir, rgb, i_env, i_cam, i_step)
-            output_depth(output_dir, depth, i_env, i_cam, i_step)
+            export_rgb(output_dir, rgb, i_env, i_cam, i_step)
+            export_depth(output_dir, depth_cutoff_dist, depth, i_env, i_cam, i_step, depth_scale)
 
-def output_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx):
+def export_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx):
     rgb = rgb.cpu().numpy()[i_env]
     cv2.imwrite(f'{output_dir}/rgb_env{i_env}_cam{cam_idx}_{i_step:03d}.png', rgb)
 
-def output_depth_single_cam(output_dir, depth, i_env, i_step, cam_idx):
+def export_depth_single_cam(output_dir, depth_cutoff_dist, depth, i_env, i_step, cam_idx, depth_scale='linear'):
     depth = depth.cpu().numpy()[i_env]
-    depth = np.clip(depth, 0, 100)
+    depth = np.clip(depth, 0, depth_cutoff_dist)
+    if depth_scale == 'log':
+        depth = np.log1p(depth)  # log1p is log(1+x) which handles 0 values safely
     depth_normalized = cv2.normalize(depth, None, 0, 255, cv2.NORM_MINMAX)
     depth_uint8 = depth_normalized.astype(np.uint8)
     cv2.imwrite(f'{output_dir}/depth_env{i_env}_cam{cam_idx}_{i_step:03d}.png', depth_uint8)
 
-def output_rgb_and_depth_single_cam(output_dir, rgb, depth, i_step, cam_idx):
+def export_rgb_and_depth_single_cam(output_dir, depth_cutoff_dist, rgb, depth, i_step, cam_idx, depth_scale='linear'):
     # loop over the first and second dimension of rgb and depth
     for i_env in range(rgb.shape[0]):
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
-        output_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx)
-        output_depth_single_cam(output_dir, depth, i_env, i_step, cam_idx)
-
+        export_rgb_single_cam(output_dir, rgb, i_env, i_step, cam_idx)
+        export_depth_single_cam(output_dir, depth_cutoff_dist, depth, i_env, i_step, cam_idx, depth_scale)
 
 if __name__ == "__main__":
     main()

--- a/src/bridge/madrona_gs/simple_demo.py
+++ b/src/bridge/madrona_gs/simple_demo.py
@@ -50,7 +50,7 @@ def main():
         fov=45,
         GUI=True,
     )
-    cam_0.attach(franka.links[0], trans_to_T(np.array([0.0, 0.5, 0.0])))
+    cam_0.attach(franka.links[6], trans_to_T(np.array([0.0, 0.5, 0.0])))
     cam_1 = scene.add_camera(
         pos=(1.5, -0.5, 1.5),
         lookat=(0.0, 0.0, 0.5),

--- a/src/bridge/sim.cpp
+++ b/src/bridge/sim.cpp
@@ -170,7 +170,7 @@ Sim::Sim(Engine &ctx,
         ctx.get<Position>(cam) = Vector3::zero();
         ctx.get<Rotation>(cam) = Quat { 1, 0, 0, 0 };
         render::RenderingSystem::attachEntityToView(
-            ctx, cam, cfg.camFovy[cam_idx], 0.001f, Vector3::zero());
+            ctx, cam, cfg.camFovy[cam_idx], 0.001f, 100.f, Vector3::zero());
     }
     
     for (CountT light_idx = 0; light_idx < (CountT)cfg.numLights; light_idx++) {

--- a/src/mw/device/bvh_raycast.cpp
+++ b/src/mw/device/bvh_raycast.cpp
@@ -1023,14 +1023,14 @@ extern "C" __global__ void bvhRaycastEntry()
                 writeDepth(global_pixel_byte_off, result.depth);
             } else {
                 writeRGB(global_pixel_byte_off, { 0.f, 0.f, 0.f });
-                writeDepth(global_pixel_byte_off, 0.f);
+                writeDepth(global_pixel_byte_off, INFINITY);
             }
         } else {
             // Only write depth information
             if (result.hit) {
                 writeDepth(global_pixel_byte_off, result.depth);
             } else {
-                writeDepth(global_pixel_byte_off, 0.f);
+                writeDepth(global_pixel_byte_off, INFINITY);
             }
         }
 

--- a/src/mw/device/bvh_raycast.cpp
+++ b/src/mw/device/bvh_raycast.cpp
@@ -790,7 +790,7 @@ static __device__ TraceResult traceRay(
                     cudaTextureObject_t *tex = &bvhParams.textures[mat->textureIdx];
 
                     float4 sampled_color = tex2D<float4>(*tex,
-                            tri_hit.uv.x, 1.f - tri_hit.uv.y);
+                            tri_hit.uv.x, tri_hit.uv.y);
 
                     Vector3 tex_color = { sampled_color.x,
                         sampled_color.y,

--- a/src/render/asset_processor.cpp
+++ b/src/render/asset_processor.cpp
@@ -300,6 +300,7 @@ MaterialData initMaterialData(
             tex_desc.filterMode = cudaFilterModeLinear;
             tex_desc.readMode = cudaReadModeNormalizedFloat;
             tex_desc.normalizedCoords = 1;
+            tex_desc.sRGB = 1;
 
             cudaTextureObject_t tex_obj = 0;
             REQ_CUDA(cudaCreateTextureObject(&tex_obj,
@@ -337,6 +338,7 @@ MaterialData initMaterialData(
             tex_desc.filterMode = cudaFilterModeLinear;
             tex_desc.readMode = cudaReadModeNormalizedFloat;
             tex_desc.normalizedCoords = 1;
+            tex_desc.sRGB = 1;
 
             cudaTextureObject_t tex_obj = 0;
             REQ_CUDA(cudaCreateTextureObject(&tex_obj,

--- a/src/render/core_wip/metal/shaders/shader_common.h
+++ b/src/render/core_wip/metal/shaders/shader_common.h
@@ -67,7 +67,8 @@ struct alignas(16) PerspectiveCameraData {
     float xScale;
     float yScale;
     float zNear;
-    uint32_t pad[2];
+    float zFar;
+    uint32_t pad[1];
 };
 
 struct alignas(16) DrawInstanceData {

--- a/src/render/ecs_system.cpp
+++ b/src/render/ecs_system.cpp
@@ -731,8 +731,7 @@ void attachEntityToView(Context &ctx,
         x_scale, y_scale, 
         z_near, 
         z_far,
-        ctx.worldID().idx,
-        0 // Padding
+        ctx.worldID().idx
     };
 
     if (raycast_enabled) {

--- a/src/render/ecs_system.cpp
+++ b/src/render/ecs_system.cpp
@@ -328,6 +328,7 @@ inline void viewTransformUpdate(Context &ctx,
     cam_data.xScale = x_scale;
     cam_data.yScale = y_scale;
     cam_data.zNear = cam.zNear;
+    cam_data.zFar = cam.zFar;
 
     Vector3 camera_pos = pos + cam.cameraOffset;
     cam_data.position = camera_pos;
@@ -690,13 +691,14 @@ void attachEntityToView(Context &ctx,
                         Entity e,
                         float vfov_degrees,
                         float z_near,
+                        float z_far,
                         const math::Vector3 &camera_offset)
 {
     float fov_scale = 1.0f / tanf(toRadians(vfov_degrees * 0.5f));
 
     Entity camera_entity = ctx.makeEntity<RenderCameraArchetype>();
     ctx.get<RenderCamera>(e) = { 
-        camera_entity, fov_scale, z_near, camera_offset 
+        camera_entity, fov_scale, z_near, z_far, camera_offset 
     };
 
     PerspectiveCameraData &cam_data = 
@@ -728,6 +730,7 @@ void attachEntityToView(Context &ctx,
         { /* Rotation */ }, 
         x_scale, y_scale, 
         z_near, 
+        z_far,
         ctx.worldID().idx,
         0 // Padding
     };

--- a/src/render/shaders/shader_common.h
+++ b/src/render/shaders/shader_common.h
@@ -225,6 +225,7 @@ struct PerspectiveCameraData {
     float xScale;
     float yScale;
     float zNear;
+    float zFar;
     int32_t worldID;
 };
 

--- a/src/render/shaders/shader_utils.hlsl
+++ b/src/render/shaders/shader_utils.hlsl
@@ -33,6 +33,8 @@ PerspectiveCameraData unpackViewData(PackedViewData packed)
     cam.xScale = d1.w;
     cam.yScale = d2.x;
     cam.zNear = d2.y;
+    cam.zFar = d2.z;
+    cam.worldID = asint(d2.w);
 
     return cam;
 }


### PR DESCRIPTION
Depth buffers from RT and rasterizer are now consistent.
Export far plane distance to camera to correctly calculate linear depth with reversed-z depth buffer
Swizzle color channel order to rgb in renderer.gs
Invalidate BVH CUDA cache when dirty
Load textures as SRGB in RT pipeline.  (Right now, we only support diffuse.  Later we need to set SRGB accordingly if there are non-color textures)